### PR TITLE
ChArUco calibration fixes

### DIFF
--- a/setup/windows/install.py
+++ b/setup/windows/install.py
@@ -26,7 +26,7 @@ import time
 ################################
 # install/update python stuff
 os.system('pip3 install pip --upgrade --user')
-os.system('pip3 install opencv-contrib-python --user')
+os.system('pip3 install "opencv-contrib-python<4.7" --user') #There are breaking changes >=4.7
 os.system('pip3 install psutil --user')
 os.system('pip3 install imageio') #required for catalog creation
 os.system('pip3 install astropy') #required for catalog creation


### PR DESCRIPTION
I have taken the liberty to change the newly added ChArUco target calibration script, such that it is able to accept images that contain only parts of the target. This is a great advantage of ChArUco compared to normal checkerboard targets, which only allow fully contained targets. With this feature, users are enabled to calibrate the camera accurately in the entire field of view.

I have tested the functionality of the addition using my own dataset.

A second addition is the version constraint of the `opencv-contrib-python` dependency, which has a breaking change in the ArUco api from 4.7.0 on.