### PR TITLE
Fixed undistortion bug

### DIFF
--- a/py_src/star_tracker/star_tracker/main.py
+++ b/py_src/star_tracker/star_tracker/main.py
@@ -78,11 +78,9 @@ def star_tracker(img_file_name, cam_config_file_name, m=None, q=None, x_cat=None
         return q_est, idmatch, nmatches, x_obs, img
 
     if undist_img_bool is True:
-        centroidsUnd = centroids.reshape(len(centroids), 1, 2)
-        undistorted_centroids_offsets = cv2.undistortPoints(
-            centroidsUnd, camera_matrix, dist_coefs)
-        centroids = (centroidsUnd + undistorted_centroids_offsets)
-        centroids = centroids.reshape((len(centroidsUnd), 2))
+        centroids = cv2.undistortPoints(
+            centroids[:, None], camera_matrix, dist_coefs, P=camera_matrix
+        )[:, 0]
 
     if graphics is True:
         import matplotlib.pyplot as plt


### PR DESCRIPTION
I have found and fixed a bug in the undistortion of the input image. The fix increases the performance significantly using my setup.

Validation using my own data (70mm, full frame, 1.5Mpix, RMS_reproj_err_pix: 0.164):
- Before fix: 5 matches, 6.19 seconds processing time
- After fix: 25 matches, 0.44 seconds processing time

Thank you for considering this pull request.